### PR TITLE
AccessToken to take lifetime as optional argument when instantiating

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -282,12 +282,11 @@ class RefreshToken(BlacklistMixin, Token):
 
 class AccessToken(Token):
     token_type = 'access'
-    def __init__(self, lifetime=None):
-        if not lifetime:
-            self.lifetime = api_settings.ACCESS_TOKEN_LIFETIME
-        else:
+    lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+    def __init__(self, token=None, verify=True, lifetime=None):
+        if lifetime:
             self.lifetime = lifetime
-        super(AccessToken, self).__init__()
+        super(AccessToken, self).__init__(token, verify)
 
 
 class UntypedToken(Token):

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -282,7 +282,12 @@ class RefreshToken(BlacklistMixin, Token):
 
 class AccessToken(Token):
     token_type = 'access'
-    lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+    def __init__(self, lifetime=None):
+        if not lifetime:
+            self.lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+        else:
+            self.lifetime = lifetime
+        super(AccessToken, self).__init__()
 
 
 class UntypedToken(Token):

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -283,7 +283,7 @@ class RefreshToken(BlacklistMixin, Token):
 class AccessToken(Token):
     token_type = 'access'
     lifetime = api_settings.ACCESS_TOKEN_LIFETIME
-    
+
     def __init__(self, *args, **kwargs):
         lifetime = kwargs.pop('lifetime', None)
         if lifetime:

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -283,10 +283,13 @@ class RefreshToken(BlacklistMixin, Token):
 class AccessToken(Token):
     token_type = 'access'
     lifetime = api_settings.ACCESS_TOKEN_LIFETIME
-    def __init__(self, token=None, verify=True, lifetime=None):
+    
+    def __init__(self, *args, **kwargs):
+        lifetime = kwargs.pop('lifetime', None)
         if lifetime:
             self.lifetime = lifetime
-        super(AccessToken, self).__init__(token, verify)
+
+        super(AccessToken, self).__init__(*args, **kwargs)
 
 
 class UntypedToken(Token):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -322,7 +322,7 @@ class TestAccessToken(TestCase):
 
     def test_init_with_timedelta(self):
         now = make_utc(datetime(year=2000, month=1, day=1))
-        token = AccessToken(timedelta(minutes=10))
+        token = AccessToken(lifetime=timedelta(minutes=10))
         token.current_time = now
         token.set_exp()
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -320,6 +320,14 @@ class TestAccessToken(TestCase):
         token = AccessToken()
         self.assertEqual(token[api_settings.TOKEN_TYPE_CLAIM], 'access')
 
+    def test_init_with_timedelta(self):
+        now = make_utc(datetime(year=2000, month=1, day=1))
+        token = AccessToken(timedelta(minutes=10))
+        token.current_time = now
+        token.set_exp()
+
+        self.assertEqual(token['exp'], datetime_to_epoch(now + timedelta(minutes=10)))
+
 
 class TestRefreshToken(TestCase):
     def test_init(self):


### PR DESCRIPTION
Thanks for that nice django app. I use it in my django app, even though i modified the authentication classes, views and serializer a bit to match my use case. However, when i wrote my tests, i thought it would be useful to create access tokens on the fly with different lifetimes. 

What do you think?