### PR TITLE
Custom username field

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -19,6 +19,7 @@ class PasswordField(serializers.CharField):
 
 class TokenObtainSerializer(serializers.Serializer):
     username_field = User.USERNAME_FIELD
+    custom_username_field = api_settings.CUSTOM_USERNAME_FIELD
 
     default_error_messages = {
         'no_active_account': _('No active account found with the given credentials')
@@ -27,12 +28,16 @@ class TokenObtainSerializer(serializers.Serializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields[self.username_field] = serializers.CharField()
+        self.fields[self.username] = serializers.CharField()
         self.fields['password'] = PasswordField()
+
+    @property
+    def username(self):
+        return self.custom_username_field if self.custom_username_field else self.username_field
 
     def validate(self, attrs):
         authenticate_kwargs = {
-            self.username_field: attrs[self.username_field],
+            self.username_field: attrs[self.username],
             'password': attrs['password'],
         }
         try:

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -18,7 +18,7 @@ class PasswordField(serializers.CharField):
 
 
 class TokenObtainSerializer(serializers.Serializer):
-    username_field = User.USERNAME_FIELD
+    default_username_field = User.USERNAME_FIELD
     custom_username_field = api_settings.CUSTOM_USERNAME_FIELD
 
     default_error_messages = {
@@ -28,16 +28,16 @@ class TokenObtainSerializer(serializers.Serializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields[self.username] = serializers.CharField()
+        self.fields[self.username_field] = serializers.CharField()
         self.fields['password'] = PasswordField()
 
     @property
-    def username(self):
-        return self.custom_username_field if self.custom_username_field else self.username_field
+    def username_field(self):
+        return self.custom_username_field if self.custom_username_field else self.default_username_field
 
     def validate(self, attrs):
         authenticate_kwargs = {
-            self.username_field: attrs[self.username],
+            self.default_username_field: attrs[self.username_field],
             'password': attrs['password'],
         }
         try:

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     'AUTH_HEADER_TYPES': ('Bearer',),
     'USER_ID_FIELD': 'id',
     'USER_ID_CLAIM': 'user_id',
+    'CUSTOM_USERNAME_FIELD': None,
 
     'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
     'TOKEN_TYPE_CLAIM': 'token_type',


### PR DESCRIPTION
As I was customizing Django User model I've encounter a problem when I decided to use two field as username (email, phone_number) so then user can login with both email and phone number. This PR will help to customize the username field label in create token endpoint so we can specify a custom name for our username field (lets say `identity` instead of `email` or `phone number`)