### PR TITLE
Ensure django "observes"  login on token obtaining 

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, user_logged_in
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 
@@ -54,6 +54,9 @@ class TokenObtainSerializer(serializers.Serializer):
                 self.error_messages['no_active_account'],
                 'no_active_account',
             )
+
+        user_cls = self.user.__class__
+        user_logged_in.send(sender=user_cls, request=self.context['request'], user=self.user)
 
         return {}
 


### PR DESCRIPTION
In order to update the **last_login** and make sure all the login routines are triggered when obtaining the auth token, the safest way in my opinion is to send this signal.

Docs:
https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.signals.user_logged_in

Currently that's the workaround i'm using on a private repo