### PR TITLE
Remove upper version bound for the python requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'djangorestframework',
         'pyjwt',
     ],
-    python_requires='>=3.6,<3.9',
+    python_requires='>=3.6',
     extras_require=extras_require,
     packages=find_packages(exclude=['tests', 'tests.*', 'licenses', 'requirements']),
     include_package_data=True,


### PR DESCRIPTION
This PR removes the upper bound for the required python version.

As described in #224, the current python version requirement, which includes both a lower and an upper bound, makes it troublesome to use poetry to install this package.

The proposed implementation fixes #224 and allows easy installation with poetry