### PR TITLE
Removed unneeded TokenUser.__ne__ method.

### DIFF
--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -51,9 +51,6 @@ class TokenUser:
     def __eq__(self, other):
         return self.id == other.id
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
         return hash(self.id)
 


### PR DESCRIPTION
This method is not needed since Python 3 is the minimum requirement.