### PR TITLE
OutstandingToken user should be nullified with SET_NULL

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/migrations/0007_auto_20171017_2214.py
+++ b/rest_framework_simplejwt/token_blacklist/migrations/0007_auto_20171017_2214.py
@@ -18,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='outstandingtoken',
             name='user',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL),
         ),
     ]

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 
 class OutstandingToken(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, blank=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True)
 
     jti = models.CharField(unique=True, max_length=255)
     token = models.TextField()


### PR DESCRIPTION
Fixes #266 #232 #201 

Originally, in the model of OutstandingToken, you can see that the user attribute is supposed to be null if the user is deleted. If it remained `on_delete=models.CASCADE` then there would be no point in `null=True` and `blank=True`. I think the implementation was just unintended behavior, so the cascading on user deletion should set the OutstandingToken's user to null.