### PR TITLE
Set permission class AllowAny for all drf-simplejwt Views

### DIFF
--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -1,4 +1,5 @@
 from rest_framework import generics, status
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from . import serializers
@@ -7,7 +8,7 @@ from .exceptions import InvalidToken, TokenError
 
 
 class TokenViewBase(generics.GenericAPIView):
-    permission_classes = ()
+    permission_classes = (AllowAny, )
     authentication_classes = ()
 
     serializer_class = None


### PR DESCRIPTION
All views exposed by django-rest-framework-simplejwt are authentication views and thus should be accessible to unauthenticated clients. Setting a default class allows users to use this library and set a default DRF IsAuthenticated policy in their settings file, without subclassing all the views here manually and exposing them to the world. This is also inline with other DRF authentication libraries.