### PR TITLE
Update README with template repositories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,19 @@ Framework <http://www.django-rest-framework.org/>`__.
 For full documentation, visit `django-rest-framework-simplejwt.readthedocs.io
 <https://django-rest-framework-simplejwt.readthedocs.io/en/latest/>`__.
 
+Visit our template repositories to jumpstart your Django + SimpleJWT project
+with an already-configured frontend:
+
+- `Android <https://github.com/Andrew-Chen-Wang/mobile-auth-example>`__
+- `Angular <https://github.com/SimpleJWT/drf-SimpleJWT-Angular>`__
+- `iOS <https://github.com/Andrew-Chen-Wang/mobile-auth-example>`__
+- `React <https://github.com/SimpleJWT/drf-SimpleJWT-React>`__
+- `Vue.js <https://github.com/SimpleJWT/drf-SimpleJWT-Vue>`__
+
+Don't see your frontend framework? Create an issue in our `server
+template repository <https://github.com/SimpleJWT/drf-SimpleJWT-server-template>`__,
+and we can create a repository for you.
+
 Looking for Maintainers
 -----------------------
 


### PR DESCRIPTION
Template repositories are here so that people who want to start using SimpleJWT with a frontend technology follow the best practices.

Developers generate new projects using these template repositories so that they don't need to worry about configuring the authorization and authentication on their end; they can focus solely on their own content.

This is a part of #263 