### PR TITLE
Use re_path in tests due to Django 4.0 deprecation

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,17 +1,17 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from rest_framework_simplejwt import views as jwt_views
 
 from . import views
 
 urlpatterns = [
-    url(r'^token/pair/$', jwt_views.token_obtain_pair, name='token_obtain_pair'),
-    url(r'^token/refresh/$', jwt_views.token_refresh, name='token_refresh'),
+    re_path(r'^token/pair/$', jwt_views.token_obtain_pair, name='token_obtain_pair'),
+    re_path(r'^token/refresh/$', jwt_views.token_refresh, name='token_refresh'),
 
-    url(r'^token/sliding/$', jwt_views.token_obtain_sliding, name='token_obtain_sliding'),
-    url(r'^token/sliding/refresh/$', jwt_views.token_refresh_sliding, name='token_refresh_sliding'),
+    re_path(r'^token/sliding/$', jwt_views.token_obtain_sliding, name='token_obtain_sliding'),
+    re_path(r'^token/sliding/refresh/$', jwt_views.token_refresh_sliding, name='token_refresh_sliding'),
 
-    url(r'^token/verify/$', jwt_views.token_verify, name='token_verify'),
+    re_path(r'^token/verify/$', jwt_views.token_verify, name='token_verify'),
 
-    url(r'^test-view/$', views.test_view, name='test_view'),
+    re_path(r'^test-view/$', views.test_view, name='test_view'),
 ]


### PR DESCRIPTION
Tests was showing some warnings due to a 4.0 Django deprecation warning.

* re_path was introduced in Django 2.0 which is the smallest version supported.