### PR TITLE
Improve message when validation fails due to misconfigured algorithms…

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -1,6 +1,6 @@
 import jwt
 from django.utils.translation import gettext_lazy as _
-from jwt import InvalidTokenError
+from jwt import InvalidAlgorithmError, InvalidTokenError
 
 from .exceptions import TokenBackendError
 from .utils import format_lazy
@@ -54,5 +54,7 @@ class TokenBackend:
             return jwt.decode(token, self.verifying_key, algorithms=[self.algorithm], verify=verify,
                               audience=self.audience, issuer=self.issuer,
                               options={'verify_aud': self.audience is not None})
+        except InvalidAlgorithmError as ex:
+            raise TokenBackendError(_('Invalid algorithm specified')) from ex
         except InvalidTokenError:
             raise TokenBackendError(_('Token is invalid or expired'))

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -1,6 +1,6 @@
 import jwt
 from django.utils.translation import gettext_lazy as _
-from jwt import InvalidAlgorithmError, InvalidTokenError
+from jwt import InvalidAlgorithmError, InvalidTokenError, algorithms
 
 from .exceptions import TokenBackendError
 from .utils import format_lazy
@@ -17,8 +17,7 @@ ALLOWED_ALGORITHMS = (
 
 class TokenBackend:
     def __init__(self, algorithm, signing_key=None, verifying_key=None, audience=None, issuer=None):
-        if algorithm not in ALLOWED_ALGORITHMS:
-            raise TokenBackendError(format_lazy(_("Unrecognized algorithm type '{}'"), algorithm))
+        self._validate_algorithm(algorithm)
 
         self.algorithm = algorithm
         self.signing_key = signing_key
@@ -28,6 +27,17 @@ class TokenBackend:
             self.verifying_key = signing_key
         else:
             self.verifying_key = verifying_key
+
+    def _validate_algorithm(self, algorithm):
+        """
+        Ensure that the nominated algorithm is recognized, and that cryptography is installed for those
+        algorithms that require it
+        """
+        if algorithm not in ALLOWED_ALGORITHMS:
+            raise TokenBackendError(format_lazy(_("Unrecognized algorithm type '{}'"), algorithm))
+
+        if algorithm in algorithms.requires_cryptography and not algorithms.has_crypto:
+            raise TokenBackendError(format_lazy(_("You must have cryptography installed to use {}."), algorithm))
 
     def encode(self, payload):
         """

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import jwt
 from django.test import TestCase
-from jwt import PyJWT
+from jwt import PyJWT, algorithms
 
 from rest_framework_simplejwt.backends import TokenBackend
 from rest_framework_simplejwt.exceptions import TokenBackendError
@@ -71,6 +71,15 @@ class TestTokenBackend(TestCase):
             TokenBackend('oienarst oieanrsto i', 'not_secret')
 
         TokenBackend('HS256', 'not_secret')
+
+    @patch.object(algorithms, 'has_crypto', new=False)
+    def test_init_fails_for_rs_algorithms_when_crypto_not_installed(self):
+        with self.assertRaisesRegex(TokenBackendError, 'You must have cryptography installed to use RS256.'):
+            TokenBackend('RS256', 'not_secret')
+        with self.assertRaisesRegex(TokenBackendError, 'You must have cryptography installed to use RS384.'):
+            TokenBackend('RS384', 'not_secret')
+        with self.assertRaisesRegex(TokenBackendError, 'You must have cryptography installed to use RS512.'):
+            TokenBackend('RS512', 'not_secret')
 
     def test_encode_hmac(self):
         # Should return a JSON web token for the given payload

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -263,3 +263,9 @@ class TestTokenBackend(TestCase):
         with patch.object(jwt, 'decode', new=pyjwt_without_rsa.decode):
             with self.assertRaisesRegex(TokenBackendError, 'Invalid algorithm specified'):
                 self.rsa_token_backend.decode(token)
+
+    def test_decode_when_token_algorithm_does_not_match(self):
+        token = jwt.encode(self.payload, PRIVATE_KEY, algorithm='RS256').decode('utf-8')
+
+        with self.assertRaisesRegex(TokenBackendError, 'Invalid algorithm specified'):
+            self.hmac_token_backend.decode(token)


### PR DESCRIPTION
Changes the message returned on token validation when cryptography is not installed from "Token is invalid or expired" to "Invalid algorithm specified"

This can actually happen for two reasons:
1. The algorithm specified in the token header is not the algorithm specified in SIMPLE_JWT settings
2. The algorithm specified in the token header does match the one specified in SIMPLE_JWT settings, but that algorithm is not available (i.e. cryptography is not installed)

I couldn't seem to get tox to pass using the instructions [here](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/development_and_contributing.html), isort seemed to want to butcher everything but happy to try again if there's any pointers to get that working.
