### PR TITLE
Update supported Python versions and restore 3.7 support 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: docs
+  python37-drf310:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: 'py37-django{22,30}-drf310-tests'
   python38-drf310:
     <<: *common
     docker:
@@ -54,6 +60,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: 'py39-django{22,30}-drf310-tests'
+  python37-other:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: 'py37-django{22,30,31}-drf{311,312}-tests'
   python38-other:
     <<: *common
     docker:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,7 +6,7 @@ Getting started
 Requirements
 ------------
 
-* Python (3.8, 3.9)
+* Python (3.7, 3.8, 3.9)
 * Django (2.2, 3.0, 3.1)
 * Django REST Framework (3.10, 3.11, 3.12)
 

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{38,39}-django{22,30}-drf310-tests
-    py{38,39}-django{22,30,31}-drf{311,312}-tests
+    py{37,38,39}-django{22,30}-drf310-tests
+    py{37,38,39}-django{22,30,31}-drf{311,312}-tests
     py39-djangomaster-drf312-tests
     lint
     docs


### PR DESCRIPTION
Rebased PR for #328

[Python 3.7 is supported until 2023-06](https://www.python.org/dev/peps/pep-0537/#lifespan), so I believe it's important not to drop support for it yet.