### PR TITLE
Test with both PyJWT v1 and v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,37 +60,37 @@ jobs:
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: 'py37-django{22,30}-drf310-tests'
+          TOXENV: 'py37-django{22,30}-drf310-pyjwt{1,2}-tests'
   python38-drf310:
     <<: *common
     docker:
       - image: circleci/python:3.8
         environment:
-          TOXENV: 'py38-django{22,30}-drf310-tests'
+          TOXENV: 'py38-django{22,30}-drf310-pyjwt{1,2}-tests'
   python39-drf310:
     <<: *common
     docker:
       - image: circleci/python:3.9
         environment:
-          TOXENV: 'py39-django{22,30}-drf310-tests'
+          TOXENV: 'py39-django{22,30}-drf310-pyjwt{1,2}-tests'
   python37-other:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: 'py37-django{22,30,31}-drf{311,312}-tests'
+          TOXENV: 'py37-django{22,30,31}-drf{311,312}-pyjwt{1,2}-tests'
   python38-other:
     <<: *common
     docker:
       - image: circleci/python:3.8
         environment:
-          TOXENV: 'py38-django{22,30,31}-drf{311,312}-tests'
+          TOXENV: 'py38-django{22,30,31}-drf{311,312}-pyjwt{1,2}-tests'
   python39-other:
     <<: *common
     docker:
       - image: circleci/python:3.9
         environment:
-          TOXENV: 'py39-django{22,30,31}-drf{311,312}-tests'
+          TOXENV: 'py39-django{22,30,31}-drf{311,312}-pyjwt{1,2}-tests'
   djangomaster:
     working_directory: ~/repo
     steps:
@@ -106,7 +106,7 @@ jobs:
     docker:
       - image: circleci/python:3.9
         environment:
-          TOXENV: 'py39-djangomaster-drf312-tests'
+          TOXENV: 'py39-djangomaster-drf312-pyjwt{1,2}-tests'
   lint:
     <<: *common
     docker:

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{37,38,39}-django{22,30}-drf310-tests
-    py{37,38,39}-django{22,30,31}-drf{311,312}-tests
-    py39-djangomaster-drf312-tests
+    py{37,38,39}-django{22,30}-drf310-pyjwt{1,2}-tests
+    py{37,38,39}-django{22,30,31}-drf{311,312}-pyjwt{1,2}-tests
+    py39-djangomaster-drf312-pyjwt{1,2}-tests
     lint
     docs
 
@@ -36,6 +36,8 @@ deps=
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
+    pyjwt1: pyjwt>=1.7,<2
+    pyjwt2: pyjwt>=2,<3
     py39-django31-drf312: codecov
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 whitelist_externals=make


### PR DESCRIPTION
As per the sole commit:

> Commit 073d83c added initial support for PyJWT>=2.0.0a1; full support for PyJWT>=2.0.0 should come with #349. However, we should still support PyJWT v1, at least the latest v1.7.1. This commit therefore adds axes to tox to test against both versions.