### PR TITLE
Support overriding the token class in RefreshToken.access_token

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -250,6 +250,7 @@ class SlidingToken(BlacklistMixin, Token):
 class RefreshToken(BlacklistMixin, Token):
     token_type = 'refresh'
     lifetime = api_settings.REFRESH_TOKEN_LIFETIME
+    access_token_class = None
     no_copy_claims = (
         api_settings.TOKEN_TYPE_CLAIM,
         'exp',
@@ -269,7 +270,7 @@ class RefreshToken(BlacklistMixin, Token):
         claims present in this refresh token to the new access token except
         those claims listed in the `no_copy_claims` attribute.
         """
-        access = AccessToken()
+        access = (access_token_class or AccessToken)()
 
         # Use instantiation time of refresh token as relative timestamp for
         # access token "exp" claim.  This ensures that both a refresh and

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -270,7 +270,7 @@ class RefreshToken(BlacklistMixin, Token):
         claims present in this refresh token to the new access token except
         those claims listed in the `no_copy_claims` attribute.
         """
-        access = (access_token_class or AccessToken)()
+        access = (self.access_token_class or AccessToken)()
 
         # Use instantiation time of refresh token as relative timestamp for
         # access token "exp" claim.  This ensures that both a refresh and


### PR DESCRIPTION
I have a usecase where different types of user should have different access and refresh token lifetimes. Inheriting from `RefreshToken` and setting `lifetime` is easy enough for setting the refresh token lifetime, but changing the lifetime of the access token requires slightly more work.

This PR simply exposes a class variable that can be set to override the class used for the access token. I've used the `None` default since the `AccessToken` is defined later in the file, but changing the order of class definitions could reduce/remove the need for that.

Edit: Having now implemented this in a full project, there are several places where I needed to make the `RefreshToken` customisable too - I can update this PR to contain all those similar changes, but would like to know if there is an appetite to include that in the project?